### PR TITLE
feat: 결제 완료 이벤트transactional outbox 패턴 적용

### DIFF
--- a/PaymentService/src/main/java/com/example/PaymentService/entity/PaymentOutbox.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/entity/PaymentOutbox.java
@@ -1,0 +1,38 @@
+package com.example.PaymentService.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "payment-outbox")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class PaymentOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String aggregateType;
+
+    private String aggregateId;
+
+    private String eventType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private JsonNode payload;
+
+    @Builder
+    public PaymentOutbox(String aggregateType, String aggregateId, String eventType, JsonNode payload) {
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+}

--- a/PaymentService/src/main/java/com/example/PaymentService/event/DomainEvent.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/event/DomainEvent.java
@@ -1,0 +1,7 @@
+package com.example.PaymentService.event;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS)
+public abstract class DomainEvent {
+}

--- a/PaymentService/src/main/java/com/example/PaymentService/event/EnrichedDomainEvent.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/event/EnrichedDomainEvent.java
@@ -1,0 +1,17 @@
+package com.example.PaymentService.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EnrichedDomainEvent<T extends DomainEvent> {
+    private String aggregateType;
+    private String aggregateId;
+    private T domainEvent;
+
+}

--- a/PaymentService/src/main/java/com/example/PaymentService/event/PaymentResultDomainEvent.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/event/PaymentResultDomainEvent.java
@@ -1,0 +1,16 @@
+package com.example.PaymentService.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+@Builder
+public class PaymentResultDomainEvent extends DomainEvent {
+    private String orderId;
+    private String paymentId;
+    private String paymentStatus;
+}

--- a/PaymentService/src/main/java/com/example/PaymentService/repository/PaymentOutboxRepository.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/repository/PaymentOutboxRepository.java
@@ -1,0 +1,14 @@
+package com.example.PaymentService.repository;
+
+import com.example.PaymentService.entity.PaymentOutbox;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+public interface PaymentOutboxRepository extends JpaRepository<PaymentOutbox, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Page<PaymentOutbox> findAllByOrderByIdAsc(Pageable pageable);
+}

--- a/PaymentService/src/main/java/com/example/PaymentService/scheduler/OutboxMessageRelay.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/scheduler/OutboxMessageRelay.java
@@ -1,0 +1,68 @@
+package com.example.PaymentService.scheduler;
+
+import com.example.PaymentService.entity.PaymentOutbox;
+import com.example.PaymentService.event.PaymentResultDomainEvent;
+import com.example.PaymentService.repository.PaymentOutboxRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ecommerce.protobuf.EdaMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@Transactional
+public class OutboxMessageRelay {
+
+    private static Logger logger = LoggerFactory.getLogger(OutboxMessageRelay.class);
+
+    @Autowired
+    private PaymentOutboxRepository paymentOutboxRepository;
+
+    @Autowired
+    private KafkaTemplate<String, byte[]> kafkaTemplate;
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Scheduled(fixedDelay = 5000)
+    public void publishOutboxMessages() {
+        logger.info("Publishing outbox messages");
+        List<PaymentOutbox> entities = paymentOutboxRepository.findAllByOrderByIdAsc(Pageable.ofSize(10)).toList();
+
+        for (PaymentOutbox entity : entities) {
+            try {
+                // 1. JSON payload 도메인 이벤트 역직렬화
+                PaymentResultDomainEvent event = objectMapper.treeToValue(
+                        entity.getPayload(), PaymentResultDomainEvent.class);
+
+                // 2. 도메인 이벤트 Protobuf 메시지 변환
+                var paymentResultMessage = EdaMessage.PaymentResultV1.newBuilder()
+                        .setOrderId(Long.parseLong(event.getOrderId()))
+                        .setPaymentId(Long.parseLong(event.getPaymentId()))
+                        .setPaymentStatus(event.getPaymentStatus())
+                        .build();
+
+                // 3. Kafka 전송
+                kafkaTemplate.send("payment_result", paymentResultMessage.toByteArray());
+
+                logger.info("Published payment_result: {}", paymentResultMessage);
+            } catch (Exception e) {
+                logger.error("Failed to publish outbox message: {}", entity, e);
+            }
+        }
+
+        // 4. 발송 완료 후 삭제
+        paymentOutboxRepository.deleteAllInBatch();
+    }
+}

--- a/PaymentService/src/main/java/com/example/PaymentService/service/EventListener.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/service/EventListener.java
@@ -1,11 +1,14 @@
 package com.example.PaymentService.service;
 
 import com.example.PaymentService.entity.Payment;
+import com.example.PaymentService.event.EnrichedDomainEvent;
+import com.example.PaymentService.event.PaymentResultDomainEvent;
 import com.google.protobuf.InvalidProtocolBufferException;
 import ecommerce.protobuf.EdaMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -18,9 +21,6 @@ public class EventListener {
     @Autowired
     private PaymentService paymentService;
 
-    @Autowired
-    private KafkaTemplate<String, byte[]> kafkaTemplate;
-
     @KafkaListener(topics = "payment_request")
     public void consumePaymentResult(byte[] message) throws Exception {
         var object = EdaMessage.PaymentRequestV1.parseFrom(message);
@@ -31,13 +31,5 @@ public class EventListener {
                 object.getOrderId(),
                 object.getAmountKRW(),
                 object.getPaymentMethodId());
-
-        var paymentResultMessage = EdaMessage.PaymentResultV1.newBuilder()
-                .setOrderId(payment.getOrderId())
-                .setPaymentId(payment.getId())
-                .setPaymentStatus(payment.getPaymentStatus().toString())
-                .build();
-
-        kafkaTemplate.send("payment_result", paymentResultMessage.toByteArray());
     }
 }

--- a/PaymentService/src/main/java/com/example/PaymentService/service/OutboxService.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/service/OutboxService.java
@@ -25,7 +25,7 @@ public class OutboxService {
                 PaymentOutbox.builder()
                         .aggregateType(enrichedDomainEvent.getAggregateType())
                         .aggregateId(enrichedDomainEvent.getAggregateId())
-                        .eventType("payment-result")
+                        .eventType("payment_result")
                         .payload(objectMapper.convertValue(enrichedDomainEvent.getDomainEvent(), JsonNode.class))
                         .build()
         );

--- a/PaymentService/src/main/java/com/example/PaymentService/service/OutboxService.java
+++ b/PaymentService/src/main/java/com/example/PaymentService/service/OutboxService.java
@@ -1,0 +1,33 @@
+package com.example.PaymentService.service;
+
+import com.example.PaymentService.entity.PaymentOutbox;
+import com.example.PaymentService.event.DomainEvent;
+import com.example.PaymentService.event.EnrichedDomainEvent;
+import com.example.PaymentService.repository.PaymentOutboxRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OutboxService {
+
+    @Autowired
+    private PaymentOutboxRepository outboxRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Transactional
+    public void handlePaymentResultDomainEvent(EnrichedDomainEvent<? extends DomainEvent> enrichedDomainEvent) {
+        outboxRepository.save(
+                PaymentOutbox.builder()
+                        .aggregateType(enrichedDomainEvent.getAggregateType())
+                        .aggregateId(enrichedDomainEvent.getAggregateId())
+                        .eventType("payment-result")
+                        .payload(objectMapper.convertValue(enrichedDomainEvent.getDomainEvent(), JsonNode.class))
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
트랜잭션 아웃박스 패턴을 사용하여 결제 완료와 주문 상태 변경을 구현할 때, 다음과 같이 동작합니다.

결제(Payment) 서비스에서 결제 작업을 시작합니다. 결제 정보는 데이터베이스에 저장되며, 해당 작업은 트랜잭션 내에서 처리됩니다.

결제 처리 작업이 성공하면 결제 서비스는 결제 완료 이벤트를 메시지 브로커(Kafka 등)를 통해 발행합니다. 이 이벤트는 다른 마이크로서비스에게 결제가 완료되었음을 알립니다.

주문(Order) 서비스는 결제 완료 이벤트를 구독하고, 해당 이벤트를 수신하여 주문 상태를 결제완료로 변경시킵니다. 이때, 주문상태를 결제완료로 변경하는 작업은 외부 시스템과의 통신이 필요하므로 트랜잭션 아웃박스 패턴을 사용합니다. 결제완료 트랜잭션과는 별개로 처리됩니다.

이러한 방식으로 트랜잭션 아웃박스 패턴을 사용하면 주문 생성과 수량 감소를 각각의 마이크로서비스에서 독립적으로 처리할 수 있습니다. 데이터베이스 트랜잭션은 각 마이크로서비스 내에서 유지되며, 외부 시스템과의 통신은 트랜잭션 아웃박스 패턴을 활용하여 안전하게 처리됩니다.